### PR TITLE
feat: implement command grouping for better help organization

### DIFF
--- a/.claude/knowledge/KNOWLEDGE_MAP.md
+++ b/.claude/knowledge/KNOWLEDGE_MAP.md
@@ -5,6 +5,7 @@
 ## 🏗️ Architecture
 
 - [Command Factory Architecture](architecture/command_factory.md) - Dual factory pattern for fast CLI startup
+- [Cobra Command Grouping](architecture/cobra_command_grouping.md) - Built-in Cobra support for organized help output
 - [Git-Native Design](architecture/git_native_design.md) - Git extension architecture with deterministic container naming
 - [SSH and Container Operations](architecture/ssh_container_operations.md) - Remote-only container management via SSH
 - [ZSH Completion System](architecture/zsh_completion.md) - Sophisticated tab completion architecture
@@ -20,6 +21,7 @@
 
 ## ✨ Features
 
+- [Command Grouping](features/command_grouping.md) - Organized help output with command categories
 - [Paste Command](features/paste_command.md) - Clipboard sharing between host and containers
 - [SSH Certificate Authority](features/ssh_certificate_authority.md) - Secure container connections with CA
 - [GitHub CLI Origin Remote](features/github_cli_origin_remote.md) - Automatic origin remote replication for gh CLI

--- a/.claude/knowledge/KNOWLEDGE_MAP_CLAUDE.md
+++ b/.claude/knowledge/KNOWLEDGE_MAP_CLAUDE.md
@@ -3,6 +3,7 @@
 ## 🏗️ Architecture
 
 - @architecture/command_factory.md - Dual factory pattern for fast CLI startup
+- @architecture/cobra_command_grouping.md - Built-in Cobra support for organized help output
 - @architecture/git_native_design.md - Git extension architecture with deterministic container naming
 - @architecture/ssh_container_operations.md - Remote-only container management via SSH
 - @architecture/zsh_completion.md - Sophisticated tab completion architecture
@@ -18,6 +19,7 @@
 
 ## ✨ Features
 
+- @features/command_grouping.md - Organized help output with command categories
 - @features/paste_command.md - Clipboard sharing between host and containers
 - @features/ssh_certificate_authority.md - Secure container connections with CA
 - @features/github_cli_origin_remote.md - Automatic origin remote replication for gh CLI

--- a/.claude/knowledge/architecture/cobra_command_grouping.md
+++ b/.claude/knowledge/architecture/cobra_command_grouping.md
@@ -1,0 +1,56 @@
+# Cobra Command Grouping Architecture
+
+Cobra provides built-in support for organizing commands into groups for better help output organization.
+
+## Core Components
+
+### Group Structure
+```go
+cobra.Group{
+    ID:    "group-id",
+    Title: "Group Title:"
+}
+```
+
+### Group Registration
+Groups must be registered on the parent command before assigning child commands:
+```go
+rootCmd.AddGroup(&cobra.Group{...})
+```
+
+### Command Assignment
+Assign commands to groups via the GroupID field:
+```go
+cmd.GroupID = "group-id"
+```
+
+## Key Requirements
+
+1. **Registration Order**: Groups MUST be defined via AddGroup() before any command sets its GroupID
+2. **Error Prevention**: Setting GroupID before AddGroup() causes "Group id 'X' is not defined" error
+3. **Complete Coverage**: Use AllChildCommandsHaveGroup() to verify all commands are grouped
+
+## Helper Methods
+
+### Built-in Commands
+- `SetHelpCommandGroupId(groupID)` - Assign help command to a group
+- `SetCompletionCommandGroupId(groupID)` - Assign completion command to a group
+
+### Validation
+- `ContainsGroup(groupID)` - Check if a group exists
+- `AllChildCommandsHaveGroup()` - Verify all commands have groups
+
+## Display Order
+
+Groups appear in the help output in the order they are defined via AddGroup(), not alphabetically.
+
+## Best Practices
+
+1. Define all groups immediately after creating the root command
+2. Use descriptive group IDs that indicate purpose
+3. Keep group titles concise but clear
+4. Ensure every command belongs to exactly one group
+5. Test help output to verify proper grouping
+
+## Related Files
+- `cmd/l8s/main.go` - Command registration and group setup

--- a/.claude/knowledge/features/command_grouping.md
+++ b/.claude/knowledge/features/command_grouping.md
@@ -1,0 +1,64 @@
+# Command Grouping Feature
+
+L8s implements command grouping in the help output to organize commands by their usage context and requirements.
+
+## Command Categories
+
+The commands are organized into four groups for better discoverability:
+
+### 1. Container Operations (Git Repository Required)
+Commands that require being in a git repository:
+- **create**: Create container from current repository
+- **ssh**: SSH into container for current repository
+- **rebuild**: Rebuild container for current repository
+- **rm/remove**: Remove container for current repository
+- **exec**: Execute command in container for current repository
+- **push**: Push changes to container (planned)
+- **pull**: Pull changes from container (planned)
+- **status**: Show status for current repository (planned)
+
+### 2. Container Management
+Commands that work with specific containers by name:
+- **start**: Start a stopped container
+- **stop**: Stop a running container
+- **info**: Show container information
+- **paste**: Paste clipboard to container
+- **remote add/remove**: Manage git remotes for containers
+
+### 3. System Setup
+Global setup and configuration commands:
+- **init**: Initialize L8s configuration
+- **install-zsh-plugin**: Install ZSH completion plugin
+- **connection**: Manage SSH connection settings
+
+### 4. Maintenance & Development
+Utility commands for maintenance:
+- **list**: List all containers
+- **rebuild-all**: Rebuild all containers
+- **build**: Build L8s binary
+
+## Implementation Details
+
+### Cobra Command Grouping
+Cobra provides built-in support for command grouping:
+
+1. **Define groups**: Use `rootCmd.AddGroup()` with ID and Title
+2. **Assign commands**: Set `GroupID` field on each command
+3. **Order matters**: Groups appear in the order they're defined
+4. **Built-in commands**: Use `SetHelpCommandGroupId()` and `SetCompletionCommandGroupId()`
+
+### Key Requirements
+- All groups must be defined before assigning commands to them
+- Every command should belong to a group for consistent help output
+- Group IDs should be descriptive (e.g., "repo-ops", "container-mgmt")
+
+## Benefits
+
+1. **Clear context requirements**: Users immediately see which commands need git context
+2. **Better discoverability**: Related commands are grouped together
+3. **Improved UX**: Reduces cognitive load when searching for commands
+4. **Explicit design**: Makes the git-native architecture visible in the interface
+
+## Related Files
+- `cmd/l8s/main.go` - Command registration and group setup
+- `pkg/cli/factory_lazy.go` - Command implementations

--- a/cmd/l8s/main.go
+++ b/cmd/l8s/main.go
@@ -28,6 +28,26 @@ accessible via SSH using key-based authentication.`,
 		SilenceErrors: true,
 	}
 
+	// Define command groups for better organization
+	rootCmd.AddGroup(
+		&cobra.Group{
+			ID:    "working",
+			Title: "Working Commands (requires git repo)",
+		},
+		&cobra.Group{
+			ID:    "repo-maintenance",
+			Title: "Repository Maintenance (requires git repo)",
+		},
+		&cobra.Group{
+			ID:    "container",
+			Title: "Container Management (works anywhere)",
+		},
+		&cobra.Group{
+			ID:    "setup",
+			Title: "Setup & Configuration",
+		},
+	)
+
 	// Create lazy command factory
 	factory := cli.NewLazyCommandFactory()
 

--- a/pkg/cli/factory_lazy.go
+++ b/pkg/cli/factory_lazy.go
@@ -96,8 +96,9 @@ func (f *LazyCommandFactory) CreateCmd() *cobra.Command {
 	var branch string
 	
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new development container",
+		Use:     "create",
+		Short:   "Create a new development container",
+		GroupID: "repo-maintenance",
 		Long:  `Creates a new development container for the current git worktree.
 
 The container name is automatically generated from the repository name and worktree path.
@@ -137,9 +138,10 @@ A git remote will be added to your local repository for easy code synchronizatio
 // SSHCmd returns the ssh command with lazy initialization
 func (f *LazyCommandFactory) SSHCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "ssh",
-		Short: "SSH into the container for the current worktree",
-		Args:  cobra.NoArgs,
+		Use:     "ssh",
+		Short:   "SSH into the container for the current worktree",
+		GroupID: "working",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -160,6 +162,7 @@ func (f *LazyCommandFactory) ListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Short:   "List all l8s containers",
+		GroupID: "container",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
@@ -179,9 +182,10 @@ func (f *LazyCommandFactory) ListCmd() *cobra.Command {
 // StartCmd returns the start command with lazy initialization
 func (f *LazyCommandFactory) StartCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "start <name>",
-		Short: "Start a stopped container",
-		Args:  cobra.ExactArgs(1),
+		Use:     "start <name>",
+		Short:   "Start a stopped container",
+		GroupID: "container",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -200,9 +204,10 @@ func (f *LazyCommandFactory) StartCmd() *cobra.Command {
 // StopCmd returns the stop command with lazy initialization
 func (f *LazyCommandFactory) StopCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "stop <name>",
-		Short: "Stop a running container",
-		Args:  cobra.ExactArgs(1),
+		Use:     "stop <name>",
+		Short:   "Stop a running container",
+		GroupID: "container",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -223,6 +228,7 @@ func (f *LazyCommandFactory) RemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove",
 		Short:   "Remove the container for the current worktree",
+		GroupID: "repo-maintenance",
 		Args:    cobra.NoArgs,
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -248,9 +254,10 @@ func (f *LazyCommandFactory) RemoveCmd() *cobra.Command {
 // InfoCmd returns the info command with lazy initialization
 func (f *LazyCommandFactory) InfoCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "info <name>",
-		Short: "Show detailed container information",
-		Args:  cobra.ExactArgs(1),
+		Use:     "info <name>",
+		Short:   "Show detailed container information",
+		GroupID: "container",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -269,9 +276,10 @@ func (f *LazyCommandFactory) InfoCmd() *cobra.Command {
 // BuildCmd returns the build command with lazy initialization
 func (f *LazyCommandFactory) BuildCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "build",
-		Short: "Build or rebuild the base container image",
-		Args:  cobra.NoArgs,
+		Use:     "build",
+		Short:   "Build or rebuild the base container image",
+		GroupID: "container",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -290,8 +298,9 @@ func (f *LazyCommandFactory) BuildCmd() *cobra.Command {
 // RemoteCmd returns the remote command with subcommands and lazy initialization
 func (f *LazyCommandFactory) RemoteCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remote",
-		Short: "Manage git remotes for containers",
+		Use:     "remote",
+		Short:   "Manage git remotes for containers",
+		GroupID: "container",
 	}
 
 	cmd.AddCommand(
@@ -337,9 +346,10 @@ func (f *LazyCommandFactory) RemoteCmd() *cobra.Command {
 // ExecCmd returns the exec command with lazy initialization
 func (f *LazyCommandFactory) ExecCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "exec <command> [args...]",
-		Short: "Execute command in the container for the current worktree",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "exec <command> [args...]",
+		Short:   "Execute command in the container for the current worktree",
+		GroupID: "working",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -358,8 +368,9 @@ func (f *LazyCommandFactory) ExecCmd() *cobra.Command {
 // InitCmd returns the init command without lazy initialization
 func (f *LazyCommandFactory) InitCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "init",
-		Short: "Initialize l8s configuration",
+		Use:     "init",
+		Short:   "Initialize l8s configuration",
+		GroupID: "setup",
 		Long: `Initialize l8s configuration by setting up remote server connection details.
 	
 l8s ONLY supports remote container management for security isolation.
@@ -378,8 +389,9 @@ You'll need:
 // RebuildCmd returns the rebuild command with lazy initialization
 func (f *LazyCommandFactory) RebuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rebuild",
-		Short: "Rebuild the container for the current worktree while preserving data",
+		Use:     "rebuild",
+		Short:   "Rebuild the container for the current worktree while preserving data",
+		GroupID: "repo-maintenance",
 		Long: `Rebuild recreates a container with the latest base image while preserving:
 - All workspace and home directory data (volumes)
 - SSH port assignment
@@ -418,8 +430,9 @@ func (f *LazyCommandFactory) RebuildCmd() *cobra.Command {
 // RebuildAllCmd returns the rebuild-all command with lazy initialization
 func (f *LazyCommandFactory) RebuildAllCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rebuild-all",
-		Short: "Rebuild all containers with updated image",
+		Use:     "rebuild-all",
+		Short:   "Rebuild all containers with updated image",
+		GroupID: "container",
 		Long: `Rebuild all containers with the latest base image while preserving their data.
 		
 This is useful after updating the base image or when you want to refresh all containers.`,
@@ -448,14 +461,15 @@ This is useful after updating the base image or when you want to refresh all con
 // PasteCmd returns the paste command with lazy initialization
 func (f *LazyCommandFactory) PasteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "paste <container> [name]",
-		Short: "Paste clipboard content to container",
-		Long: `Paste clipboard content (image or text) from your local machine to a container.
+		Use:     "paste [name]",
+		Short:   "Paste clipboard content to container",
+		GroupID: "working",
+		Long: `Paste clipboard content (image or text) from your local machine to the container for the current worktree.
 Content is saved to /tmp/claude-clipboard/ in the container.
 
 Without a custom name, files are saved as clipboard.png or clipboard.txt (replacing any existing default files).
 With a custom name, files are saved as clipboard-<name>.png or clipboard-<name>.txt (preserving existing files).`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -474,8 +488,9 @@ With a custom name, files are saved as clipboard-<name>.png or clipboard-<name>.
 // PushCmd returns the push command with lazy initialization
 func (f *LazyCommandFactory) PushCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "push",
-		Short: "Push current branch to container (fast-forward only)",
+		Use:     "push",
+		Short:   "Push current branch to container (fast-forward only)",
+		GroupID: "working",
 		Long: `Push the current git branch to the container for this worktree.
 		
 The push will fail if it would overwrite changes in the container (non-fast-forward).
@@ -499,8 +514,9 @@ Use 'l8s pull' first if the container has diverged.`,
 // PullCmd returns the pull command with lazy initialization
 func (f *LazyCommandFactory) PullCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "pull",
-		Short: "Pull changes from container (fast-forward only)",
+		Use:     "pull",
+		Short:   "Pull changes from container (fast-forward only)",
+		GroupID: "working",
 		Long: `Pull changes from the container to your local worktree.
 		
 The pull will fail if it would overwrite local changes (non-fast-forward).
@@ -524,10 +540,11 @@ Resolve conflicts manually if your local branch has diverged.`,
 // StatusCmd returns the status command with lazy initialization
 func (f *LazyCommandFactory) StatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "status",
-		Short: "Show status of container for current worktree",
-		Long:  `Display the status and information about the container associated with the current git worktree.`,
-		Args:  cobra.NoArgs,
+		Use:     "status",
+		Short:   "Show status of container for current worktree",
+		GroupID: "working",
+		Long:    `Display the status and information about the container associated with the current git worktree.`,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := f.ensureInitialized(); err != nil {
 				return err
@@ -546,9 +563,10 @@ func (f *LazyCommandFactory) StatusCmd() *cobra.Command {
 // ConnectionCmd returns the connection command with subcommands
 func (f *LazyCommandFactory) ConnectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "connection",
-		Short: "Manage Podman connection configurations",
-		Long:  "Manage multiple Podman connection configurations for different network access scenarios",
+		Use:     "connection",
+		Short:   "Manage Podman connection configurations",
+		GroupID: "setup",
+		Long:    "Manage multiple Podman connection configurations for different network access scenarios",
 	}
 	
 	// List subcommand
@@ -601,8 +619,9 @@ func (f *LazyCommandFactory) ConnectionCmd() *cobra.Command {
 // InstallZSHPluginCmd creates the install-zsh-plugin command
 func (f *LazyCommandFactory) InstallZSHPluginCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "install-zsh-plugin",
-		Short: "Install l8s ZSH completion plugin for Oh My Zsh",
+		Use:     "install-zsh-plugin",
+		Short:   "Install l8s ZSH completion plugin for Oh My Zsh",
+		GroupID: "setup",
 		Long: `Install the l8s ZSH completion plugin to enable tab completion for l8s commands.
 
 This command will:

--- a/pkg/cli/paste_test.go
+++ b/pkg/cli/paste_test.go
@@ -23,15 +23,14 @@ func TestPasteCommandStructure(t *testing.T) {
 	cmd := factory.PasteCmd()
 
 	// Check command configuration
-	assert.Equal(t, "paste <container> [name]", cmd.Use)
+	assert.Equal(t, "paste [name]", cmd.Use)
 	assert.Contains(t, cmd.Short, "clipboard")
 	assert.NotNil(t, cmd.RunE)
 
-	// Test argument validation
-	assert.NoError(t, cmd.Args(nil, []string{"container"}))
-	assert.NoError(t, cmd.Args(nil, []string{"container", "name"}))
-	assert.Error(t, cmd.Args(nil, []string{}))
-	assert.Error(t, cmd.Args(nil, []string{"a", "b", "c"}))
+	// Test argument validation - paste now accepts 0 or 1 arg
+	assert.NoError(t, cmd.Args(nil, []string{}))
+	assert.NoError(t, cmd.Args(nil, []string{"name"}))
+	assert.Error(t, cmd.Args(nil, []string{"a", "b"}))
 }
 
 func TestRunPastePlatformCheck(t *testing.T) {

--- a/pkg/embed/host-integration/oh-my-zsh/l8s/_l8s
+++ b/pkg/embed/host-integration/oh-my-zsh/l8s/_l8s
@@ -119,8 +119,8 @@ _l8s() {
                     _l8s_get_containers
                     ;;
                 paste)
-                    # Paste still takes container name as first arg
-                    _l8s_get_containers "running"
+                    # Paste now works in git context, no container arg needed
+                    # Could complete custom names here but not implemented yet
                     ;;
                 remote)
                     # Complete remote subcommands

--- a/test/zsh-plugin/test_context_filtering.sh
+++ b/test/zsh-plugin/test_context_filtering.sh
@@ -46,11 +46,11 @@ assert_not_contains "$completions" "myproject" "Should NOT show containers for e
 assert_not_contains "$completions" "webapp" "Should NOT show containers for exec (git-native)"
 assert_not_contains "$completions" "api" "Should NOT show containers for exec (git-native)"
 
-# Test 3b: Paste command should only show running containers
+# Test 3b: Paste command is now git-native (doesn't take container arg)
 completions=$(get_completions "l8s paste ")
-assert_contains "$completions" "myproject" "Should show running container 'myproject' for paste"
-assert_contains "$completions" "webapp" "Should show running container 'webapp' for paste"
-assert_not_contains "$completions" "api" "Should NOT show stopped container 'api' for paste"
+assert_not_contains "$completions" "myproject" "Should NOT show containers for paste (git-native)"
+assert_not_contains "$completions" "webapp" "Should NOT show containers for paste (git-native)"
+assert_not_contains "$completions" "api" "Should NOT show containers for paste (git-native)"
 
 # Test 4: Only info shows all containers (remove, rm, rebuild, ssh are git-native)
 completions=$(get_completions "l8s info ")


### PR DESCRIPTION
## Summary
- Implements command grouping to organize help output (fixes #3)
- Makes paste command repo-dependent for consistency
- Creates clear separation between repo-context and global commands

## Changes

### Command Organization
Commands are now grouped into 4 logical sections in the help output:

1. **Working Commands (requires git repo)** - Daily development tasks
   - `ssh`, `exec`, `paste`, `push`, `pull`, `status`

2. **Repository Maintenance (requires git repo)** - Container lifecycle  
   - `create`, `rebuild`, `remove`

3. **Container Management (works anywhere)** - Global operations
   - `list`, `start`, `stop`, `info`, `build`, `rebuild-all`, `remote`

4. **Setup & Configuration** - Initial setup
   - `init`, `connection`, `install-zsh-plugin`

### Paste Command Update
- `paste` now derives container from current worktree (like other repo commands)
- No longer takes container parameter
- Updated tests and ZSH completions

## Test Plan
- [x] All unit tests pass
- [x] All ZSH plugin tests pass (91/91)
- [x] `make ci` completes successfully
- [x] Help output displays organized groups
- [x] Paste command works in git repository context